### PR TITLE
デプロイ先のline_callback_urlを更新

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,4 @@
 default_url_options:
   host: 'localhost:3000'
 sorcery:
-  line_callback_url: 'https://7ee8-240f-98-2ed6-1-ece0-d02b-2159-58e1.ngrok-free.app/oauth/callback?provider=line'
+  line_callback_url: 'https://menuvid.fly.dev/oauth/callback?provider=line/oauth/callback?provider=line'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,2 @@
 sorcery:
-  line_callback_url: 'https://menuvid.fly.dev/oauth/callback?provider=line
-/oauth/callback?provider=line'
+  line_callback_url: 'https://menuvid.fly.dev/oauth/callback?provider=line/oauth/callback?provider=line'


### PR DESCRIPTION
デプロイ先でLINEログインが挙動できなかった。
開発環境が反映されているため、一旦development.ymlのline_callback_urlをデプロイのURLに変更する。