### PR TITLE
callbackURLの変更

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,4 @@
 default_url_options:
   host: 'localhost:3000'
 sorcery:
-  line_callback_url: 'https://menuvid.fly.dev/oauth/callback?provider=line/oauth/callback?provider=line'
+  line_callback_url: 'https://menuvid.fly.dev/oauth/callback?provider=line'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,2 @@
 sorcery:
-  line_callback_url: 'https://menuvid.fly.dev/oauth/callback?provider=line/oauth/callback?provider=line'
+  line_callback_url: 'https://menuvid.fly.dev/oauth/callback?provider=line'


### PR DESCRIPTION
NoMethodError in OauthsController#callback
undefined method `process_callback' for nil:NilClass
というエラーがデプロイ先であり。
cakkback URLが間違っていたため、変更する。